### PR TITLE
PDE correction automatized

### DIFF
--- a/sst1mpipe/data/mc_pde_correction_factors.json
+++ b/sst1mpipe/data/mc_pde_correction_factors.json
@@ -1,0 +1,12 @@
+{
+  "MC_correction_for_PDE": {
+    "tel_001": {
+      "qe_SST1M_5477_ave_TEL1_NSB136.0": 0.9393873691700036,
+      "qe_SST1M_5477_ave_TEL1_NSB251.0": 0.9
+    },
+    "tel_002": {
+      "qe_SST1M_5477_ave_TEL2_NSB177.0": 0.9819055121768047,
+      "qe_SST1M_5477_ave_TEL2_NSB300.0": 0.9
+    }
+  }
+}

--- a/sst1mpipe/data/sst1mpipe_mc_config.json
+++ b/sst1mpipe/data/sst1mpipe_mc_config.json
@@ -64,10 +64,7 @@
         "tel_001": 1.0,
         "tel_002": 1.0
       },
-      "MC_correction_for_PDE": {
-        "tel_001": 0.9393873691700036,
-        "tel_002": 0.9819055121768047
-      }
+      "MC_correction_for_PDE": true
   },
 
     "ImageProcessor": {

--- a/sst1mpipe/io/__init__.py
+++ b/sst1mpipe/io/__init__.py
@@ -32,5 +32,7 @@ from .io import (
     load_more_dl2_files,
     load_source_catalog,
     load_distributions_sst1m,
-    write_dl1_pedestals
+    write_dl1_pedestals,
+    get_used_qe_simtel,
+    get_pde_correction_factors
 )

--- a/sst1mpipe/io/io.py
+++ b/sst1mpipe/io/io.py
@@ -1451,3 +1451,57 @@ def load_distributions_sst1m(dist_path=None, dl3_path=None):
     livetimes = np.array(livetimes).flatten()
 
     return histograms, histograms_diff, zeniths, obsids_sorted, livetimes, survived_ped, bins
+
+
+def get_used_qe_simtel(source):
+    """
+    Reads the simtel cfg file used to run current MC production and extracts
+    all Quntum efficiency (PDE) files listed there. There are also default (dummy)
+    PDE files there as the proper fields in simtel must be first initialized with
+    something before running. This is not dangerous as long us one does not 
+    use one of the real PDE files used for the real production as the dummy file..
+
+    Parameters
+    ----------
+    source: ctapipe.io.EventSource
+
+    Returns
+    -------
+    used_qe: numpy.array
+        Array of used PDEs to produce given simtel file
+
+    """
+
+    used_qe = []
+    stringlist=[x[1].decode('utf-8') for x in source.file_.history]
+    string_array = np.array(stringlist)
+    indices = np.arange(0, len(string_array))
+    index_array_eff = indices[np.char.find(string_array, 'QUANTUM_EFFiciency') != -1]
+    for string in string_array[index_array_eff]:
+        s = string.replace('QUANTUM_EFFiciency ', '').split('%')[0].strip()
+        used_qe.append(s[:s.rfind('.')])
+    return np.array(used_qe)
+
+
+def get_pde_correction_factors():
+    """
+    Reads the default calibration file containing the PDE
+    corrections for different PDE files used in MC production.
+    The file is expected to be stored in ../data/mc_pde_correction_factors.json
+
+    Returns
+    -------
+    pde_corr: dict
+
+    """
+
+    try:
+        default_pde_corr_file = 'mc_pde_correction_factors.json'
+        pde_corr_file = pkg_resources.resource_filename('sst1mpipe',path.join('data',default_pde_corr_file))
+
+        with open(pde_corr_file) as json_file:
+                pde_corr = Config(json.load(json_file))
+        return pde_corr
+    except:
+        logging.error('%s file not found! Either make sure it is there, or turn off the PDE correction in the cfg file!'.format(pde_corr_file))
+        exit()

--- a/sst1mpipe/performance/performance.py
+++ b/sst1mpipe/performance/performance.py
@@ -831,7 +831,7 @@ class irf_maker:
 
         if isfloat(self.gammaness_cut):
             logging.info('Global gammaness cut {} applied.'.format(self.gammaness_cut))
-            dl2_selected = dl2_data[(dl2_data['gammaness']>self.gammaness_cut)]
+            mask_gg = dl2_data['gammaness'] > self.gammaness_cut
         else:
             logging.info('Energy dependent gammaness cut applied.')
 
@@ -841,7 +841,10 @@ class irf_maker:
                 self.gammaness_cut,
                 operator.ge,
             )
-            dl2_selected = dl2_data[mask_gg].copy()
+        dl2_selected = dl2_data[mask_gg].copy()
+
+        # cut on delta disp
+        dl2_selected = stereo_delta_disp_cut(dl2_selected, config=self.config)
 
         # event selection is performed authomaticaly, if you provide load_dl2_sst1m with a config file
         # dl2_selected = event_selection(dl2_selected, config=self.config)

--- a/sst1mpipe/utils/utils.py
+++ b/sst1mpipe/utils/utils.py
@@ -1223,7 +1223,8 @@ def stereo_delta_disp_cut(data, config=None):
         mask = data['min_distance']*180/np.pi < config['analysis']['stereo_delta_disp_cut_deg']
         logging.info('{} deg cut on min disp distance applied.'.format(config['analysis']['stereo_delta_disp_cut_deg']))
         logging.info('N of events of stereo after delta disp cut: {} '.format(sum(mask)))
-        return data[mask]
+        data_selected = data[mask].copy()
+        return data_selected
     else:
         logging.info('No cut on min disp distance applied.')
         return data
@@ -1870,4 +1871,3 @@ def plot_livetime(hdu_dir,objects=None,ignore_sources=[]):
     plt.ylabel('observation time [h]')
     plt.xticks(rotation=45)
     return f,ax
-


### PR DESCRIPTION
I moved the Bulgarian constants in a separate file in order not to pollute the basic MC config (we can expect the number of those constants to grow in time). So every MC production should be accompanied with a PR updating this file. Note that some values there are now just placeholders and need to be replaced by Vladimir. I believe it is now relatively fool-proof, as long us someone won't start using some real PDE files from the catalog as initial placeholders in simtel config.

There is also a minor update of delta DISP cut applied also in the IRFs production, which is not important at this point.