### PR TITLE
Importing large zfits files for the integration tests using Git Large File Storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+sst1mpipe/tests/resources/zfits/SST1M1_20260121_0001.fits.fz filter=lfs diff=lfs merge=lfs -text
+sst1mpipe/tests/resources/zfits/SST1M2_20260121_0001.fits.fz filter=lfs diff=lfs merge=lfs -text
+*fits.fz filter=lfs diff=lfs merge=lfs -text

--- a/sst1mpipe/tests/resources/zfits/SST1M1_20260121_0001.fits.fz
+++ b/sst1mpipe/tests/resources/zfits/SST1M1_20260121_0001.fits.fz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06dd025134bb5046172d640c870fbefefff1b0ccab17d895c0f13f61673fcf74
+size 824967360

--- a/sst1mpipe/tests/resources/zfits/SST1M2_20260121_0001.fits.fz
+++ b/sst1mpipe/tests/resources/zfits/SST1M2_20260121_0001.fits.fz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70fb5f7e1f503e6746405af6c6da4410ab64f8521a31782b274f7bad75384144
+size 865310400


### PR DESCRIPTION
This PR add resources zfits files through Git Large File Storage later useful for testing purpose.

The files are about 800 MB each for tel 1 and 2 for the night of the 21st of January. According to observer report, these should correspond to a moon less night. 

I cannot guarantee that they contain coincident events for stereo reconstruction.

I followed this tutorial for using Github LFS : https://medium.com/swlh/learning-about-git-large-file-system-lfs-72e0c86cfbaf

 

