### PR TITLE
Trigger documentation.yml workflow after push to main

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,11 @@
 name: documentation
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
This branch was previously merged in PR #175. After the merge the ci.yml workflow started and passed however the documentation.yml worflow did not start (see https://github.com/SST-1M-collaboration/sst1mpipe/actions/runs/26028330478/workflow). This PR is to trigger the documentation.yml workflow to every push to the main/master branch.

In the documentation.yml workflow the doc page is updated only if the current branch is master.

