### PR TITLE
Fix cmap

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - jupyterlab=3.5.2
   - protozfits
   - astroquery=0.4.6
-  - matplotlib<=3.8
+  - matplotlib<=3.7 # required for CameraDisplay colorbar to work
   - nbmake # used to pytest jupyter notebooks
   - pydantic<2.0
   - pytables=3.8.0

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from ctapipe.visualization import CameraDisplay
+
+from sst1mpipe.instrument.camera import Camera
+
+
+GEOMETRY = Camera().geometry
+def test_add_colorbar():
+
+    image = np.ones(GEOMETRY.n_pixels)
+    display = CameraDisplay(geometry=GEOMETRY, image=image)
+    display.add_colorbar()


### PR DESCRIPTION
the update function in the ctapipe CameraDisplay cannot work if matplotlib > 3.7 is used.

Changed the matplotlib version and created a unit test.

