### PR TITLE
DBSCAN cleaning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.10
   - pip
   - coverage
-  - ctapipe=0.17.0
+  - ctapipe=0.18.1
   - click
   - gammapy>=1.0
   - h5py

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -190,6 +190,11 @@ class DBSCANImageCleaner(ImageCleaner):
         clustering.fit(self._distances[tel_id], sample_weight=image)
 
         mask = clustering.labels_ >= 0
+
+        if mask.sum() <= 1: # Cleaning with one pixel fails the timing computation (impossible with 0)
+
+            return np.zeros(self.subarray.tel[tel_id].camera.readout.n_pixels, dtype=bool)
+
         return mask
 
     def _precompute_distances(self):
@@ -247,6 +252,11 @@ class TimeDBSCANImageCleaner(ImageCleaner):
         clustering.fit(d, sample_weight=image)
 
         mask = clustering.labels_ >= 0
+
+        if mask.sum() <= 1: # Cleaning with one pixel fails the timing computation (impossible with 0)
+
+            return np.zeros(self.subarray.tel[tel_id].camera.readout.n_pixels, dtype=bool)
+
         return mask
 
     def _precompute_distances_squared(self):
@@ -295,6 +305,10 @@ class DBSCANImageCleaner3D(ImageCleaner):
         mask = mask.reshape((self.subarray.tel[tel_id].camera.readout.n_pixels, self.subarray.tel[tel_id].camera.readout.n_samples))
         mask = mask.sum(axis=-1)
         mask = mask >= self.min_samples.tel[tel_id]
+
+        if mask.sum() <= 1: # Cleaning with one pixel fails the timing computation (impossible with 0)
+
+            return np.zeros(self.subarray.tel[tel_id].camera.readout.n_pixels, dtype=bool)
 
         return mask
 

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -213,7 +213,7 @@ class DBSCANImageCleaner(ImageCleaner):
             d = radius_neighbors_graph(
                 x.to(u.dimensionless_unscaled),
                 radius=1.0,
-                mode="distance",
+                mode="connectivity",
                 include_self=True,
                 n_jobs=-1
             )
@@ -338,7 +338,7 @@ class DBSCANImageCleaner3D(ImageCleaner):
                 np.tile(t.to(u.ns).value / self.epsilon_t.tel[tel_id], geometry.n_pixels)
             ])
 
-            d = radius_neighbors_graph(indices_xyt, 1.0, mode="distance",
+            d = radius_neighbors_graph(indices_xyt, 1.0, mode="connectivity",
                                            include_self=True)
             d = sort_graph_by_row_values(
                 d,

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -14,6 +14,8 @@ from ctapipe.core.traits import (
     IntTelescopeParameter
 )
 
+from ctapipe.core.component import TelescopeComponent
+
 from ctapipe.image import (
     ImageCleaner,
     ImageProcessor,
@@ -261,7 +263,7 @@ class TimeDBSCANImageCleaner(ImageCleaner):
 
             self._distances_squared[tel_id] = d**2
 
-class DBSCANImageCleaner3D(ImageCleaner):
+class DBSCANImageCleaner3D(TelescopeComponent):
     """
        An image cleaner based on the sklearn.cluster.DBSCAN algorithm that uses the waveforms
        """

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -9,9 +9,8 @@ from ctapipe.containers import (
 )
 
 from ctapipe.core.traits import (
-    BoolTelescopeParameter,
     FloatTelescopeParameter,
-    IntTelescopeParameter, TelescopeParameter,
+    IntTelescopeParameter
 )
 
 from ctapipe.image import (
@@ -170,7 +169,6 @@ class ImageCleanerSST_MC(ImageCleaner):
 class DBSCANImageCleaner(ImageCleaner):
     """
     An image cleaner based on the sklearn.cluster.DBSCAN algorithm
-
     """
     minimum_pe = IntTelescopeParameter(
         default_value=30, help="Minimum number of p.e. in cluster"

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -24,7 +24,7 @@ from ctapipe.image import (
 from scipy.spatial.distance import cdist
 
 from sklearn.cluster import DBSCAN
-
+from sklearn.neighbors import radius_neighbors_graph, sort_graph_by_row_values
 
 def get_only_main_island_mask(geom, cleaning_mask):
 
@@ -200,7 +200,19 @@ class DBSCANImageCleaner(ImageCleaner):
             geometry = self.subarray.tel[tel_id].camera.geometry
             epsilon_r =self.epsilon_r.tel[tel_id] * u.mm
             x = np.column_stack([geometry.pix_x, geometry.pix_y]) / epsilon_r
-            d = cdist(x.to(u.dimensionless_unscaled), x.to(u.dimensionless_unscaled))
+
+            d = radius_neighbors_graph(
+                x.to(u.dimensionless_unscaled),
+                radius=1.0,
+                mode="distance",
+                include_self=True,
+                n_jobs=-1
+            )
+
+            d = sort_graph_by_row_values(
+                d,
+                warn_when_not_sorted=False
+            )
 
             self._distances[tel_id] = d
 

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -1,6 +1,7 @@
 import logging
 from copy import deepcopy
 
+import astropy.units as u
 import numpy as np
 from ctapipe.containers import (
     CameraHillasParametersContainer,
@@ -186,7 +187,7 @@ class DBSCANImageCleaner(ImageCleaner):
     def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray = None) -> np.ndarray:
 
         clustering = DBSCAN(eps=self.epsilon.tel[tel_id], min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
-        clustering.fit_predict(self._distances[tel_id], sample_weight=image)
+        clustering.fit(self._distances[tel_id], sample_weight=image)
 
         mask = clustering.labels_ >= 0
         return mask
@@ -204,6 +205,50 @@ class DBSCANImageCleaner(ImageCleaner):
 
             self._distances[tel_id] = d
 
+class TimeDBSCANImageCleaner(ImageCleaner):
+    """
+       An image cleaner based on the sklearn.cluster.DBSCAN algorithm that uses the image and peak time image
+       """
+    minimum_pe = IntTelescopeParameter(
+        default_value=30, help="Minimum number of p.e. in cluster"
+    ).tag(config=True)
+
+    epsilon_r = FloatTelescopeParameter(
+        default_value=25.0, help="Scale parameter for spatial coordinates (in mm)"
+    ).tag(config=True)
+
+    epsilon_t = FloatTelescopeParameter(
+        default_value=20.0, help="Scale parameter for time (in ns)"
+    ).tag(config=True)
+
+    def __init__(self, subarray, config=None, parent=None, **kwargs):
+        super().__init__(subarray, config, parent, **kwargs)
+
+        self._precompute_distances_squared()
+
+    def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray) -> np.ndarray:
+        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
+
+        times = arrival_times / self.epsilon_t.tel[tel_id]
+        d = (times[:, None] - times[None, :])**2 + self._distances_squared[tel_id]
+        d = np.sqrt(d)
+
+        clustering.fit(d, sample_weight=image)
+
+        mask = clustering.labels_ >= 0
+        return mask
+
+    def _precompute_distances_squared(self):
+        self._distances_squared = {}
+
+        for tel_id in self.subarray.tel_ids:
+
+            geometry = self.subarray.tel[tel_id].camera.geometry
+            x = np.column_stack([geometry.pix_x, geometry.pix_y])
+            d = cdist(x.value, x.value) * x.unit
+            d /= self.epsilon_r.tel[tel_id] * u.mm
+
+            self._distances_squared[tel_id] = d**2
 
 def image_cleaner_setup(subarray=None, config=None, ismc=False):
 

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -263,7 +263,7 @@ class TimeDBSCANImageCleaner(ImageCleaner):
 
             self._distances_squared[tel_id] = d**2
 
-class DBSCANImageCleaner3D(TelescopeComponent):
+class DBSCANImageCleaner3D(ImageCleaner):
     """
        An image cleaner based on the sklearn.cluster.DBSCAN algorithm that uses the waveforms
        """
@@ -288,7 +288,7 @@ class DBSCANImageCleaner3D(TelescopeComponent):
 
         self._precompute_distances()
 
-    def __call__(self, tel_id: int, waveform: np.ndarray) -> np.ndarray:
+    def __call__(self, tel_id: int, waveform: np.ndarray, arrival_times = None) -> np.ndarray:
 
         clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed', n_jobs=-1)
         clustering.fit(self._distances[tel_id], sample_weight=waveform.ravel())

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -168,7 +168,10 @@ class ImageCleanerSST_MC(ImageCleaner):
 
 
 class DBSCANImageCleaner(ImageCleaner):
+    """
+    An image cleaner based on the sklearn.cluster.DBSCAN algorithm
 
+    """
     minimum_pe = IntTelescopeParameter(
         default_value=30, help="Minimum number of p.e. in cluster"
     ).tag(config=True)

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -7,6 +7,13 @@ from ctapipe.containers import (
     CameraTimingParametersContainer,
     ImageParametersContainer,
 )
+
+from ctapipe.core.traits import (
+    BoolTelescopeParameter,
+    FloatTelescopeParameter,
+    IntTelescopeParameter, TelescopeParameter,
+)
+
 from ctapipe.image import (
     ImageCleaner,
     ImageProcessor,
@@ -14,6 +21,9 @@ from ctapipe.image import (
     number_of_islands,
     tailcuts_clean,
 )
+from scipy.spatial.distance import cdist
+
+from sklearn.cluster import DBSCAN
 
 
 def get_only_main_island_mask(geom, cleaning_mask):
@@ -155,6 +165,43 @@ class ImageCleanerSST_MC(ImageCleaner):
         if only_main_island:
             return get_only_main_island_mask(geom, time_delta_cleaning_mask)
         return time_delta_cleaning_mask
+
+
+class DBSCANImageCleaner(ImageCleaner):
+
+    minimum_pe = IntTelescopeParameter(
+        default_value=30, help="Minimum number of p.e. in cluster"
+    ).tag(config=True)
+
+    epsilon = FloatTelescopeParameter(
+        default_value=1.1, help="Scale parameter for spatial coordinates (in pixel distances)"
+    ).tag(config=True)
+
+    def __init__(self, subarray, config=None, parent=None, **kwargs):
+        super().__init__(subarray, config, parent, **kwargs)
+
+        self._precompute_distances()
+
+    def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray = None) -> np.ndarray:
+
+        clustering = DBSCAN(eps=self.epsilon.tel[tel_id], min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
+        clustering.fit_predict(self._distances[tel_id], sample_weight=image)
+
+        mask = clustering.labels_ >= 0
+        return mask
+
+    def _precompute_distances(self):
+
+        self._distances = {}
+        for tel_id in self.subarray.tel_ids:
+
+            geometry = self.subarray.tel[tel_id].camera.geometry
+            x = np.column_stack([geometry.pix_x, geometry.pix_y])
+            d = cdist(x.value, x.value) * x.unit
+            min_pixel_distance = np.min(d[d>0])
+            d /= min_pixel_distance
+
+            self._distances[tel_id] = d
 
 
 def image_cleaner_setup(subarray=None, config=None, ismc=False):

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -175,6 +175,10 @@ class DBSCANImageCleaner(ImageCleaner):
         default_value=30, help="Minimum number of p.e. in cluster"
     ).tag(config=True)
 
+    picture_threshold_pe = FloatTelescopeParameter(default_value=0.0,
+                                                help="Minimum number of p.e. in the image the pixel.",
+                                                   ).tag(config=True)
+
     epsilon_r = FloatTelescopeParameter(
         default_value=38.0, help="Scale parameter for spatial coordinates (in mm)"
     ).tag(config=True)
@@ -189,11 +193,11 @@ class DBSCANImageCleaner(ImageCleaner):
         clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed', n_jobs=-1)
         clustering.fit(self._distances[tel_id], sample_weight=image)
 
-        mask = clustering.labels_ >= 0
+        mask = (clustering.labels_ >= 0) & (image > self.picture_threshold_pe.tel[tel_id])
 
-        if mask.sum() <= 1: # Cleaning with one pixel fails the timing computation (impossible with 0)
+        if (mask.sum() <= 1) : # Cleaning with one pixel fails the timing computation (impossible with 0)
 
-            return np.zeros(self.subarray.tel[tel_id].camera.readout.n_pixels, dtype=bool)
+            mask[...] = False
 
         return mask
 
@@ -229,6 +233,10 @@ class TimeDBSCANImageCleaner(ImageCleaner):
         default_value=30, help="Minimum number of p.e. in cluster"
     ).tag(config=True)
 
+    picture_threshold_pe = FloatTelescopeParameter(default_value=0.0,
+                                                   help="Minimum number of p.e. in the image the pixel.",
+                                                   ).tag(config=True)
+
     epsilon_r = FloatTelescopeParameter(
         default_value=38.0, help="Scale parameter for spatial coordinates (in mm)"
     ).tag(config=True)
@@ -251,11 +259,11 @@ class TimeDBSCANImageCleaner(ImageCleaner):
 
         clustering.fit(d, sample_weight=image)
 
-        mask = clustering.labels_ >= 0
+        mask = (clustering.labels_) >= 0 & (image > self.picture_threshold_pe.tel[tel_id])
 
         if mask.sum() <= 1: # Cleaning with one pixel fails the timing computation (impossible with 0)
 
-            return np.zeros(self.subarray.tel[tel_id].camera.readout.n_pixels, dtype=bool)
+            mask[...] = False
 
         return mask
 

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -175,8 +175,8 @@ class DBSCANImageCleaner(ImageCleaner):
         default_value=30, help="Minimum number of p.e. in cluster"
     ).tag(config=True)
 
-    epsilon = FloatTelescopeParameter(
-        default_value=1.1, help="Scale parameter for spatial coordinates (in pixel distances)"
+    epsilon_r = FloatTelescopeParameter(
+        default_value=38.0, help="Scale parameter for spatial coordinates (in mm)"
     ).tag(config=True)
 
     def __init__(self, subarray, config=None, parent=None, **kwargs):
@@ -186,7 +186,7 @@ class DBSCANImageCleaner(ImageCleaner):
 
     def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray = None) -> np.ndarray:
 
-        clustering = DBSCAN(eps=self.epsilon.tel[tel_id], min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
+        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
         clustering.fit(self._distances[tel_id], sample_weight=image)
 
         mask = clustering.labels_ >= 0
@@ -198,10 +198,9 @@ class DBSCANImageCleaner(ImageCleaner):
         for tel_id in self.subarray.tel_ids:
 
             geometry = self.subarray.tel[tel_id].camera.geometry
-            x = np.column_stack([geometry.pix_x, geometry.pix_y])
-            d = cdist(x.value, x.value) * x.unit
-            min_pixel_distance = np.min(d[d>0])
-            d /= min_pixel_distance
+            epsilon_r =self.epsilon_r.tel[tel_id] * u.mm
+            x = np.column_stack([geometry.pix_x, geometry.pix_y]) / epsilon_r
+            d = cdist(x.to(u.dimensionless_unscaled), x.to(u.dimensionless_unscaled))
 
             self._distances[tel_id] = d
 
@@ -214,11 +213,11 @@ class TimeDBSCANImageCleaner(ImageCleaner):
     ).tag(config=True)
 
     epsilon_r = FloatTelescopeParameter(
-        default_value=25.0, help="Scale parameter for spatial coordinates (in mm)"
+        default_value=38.0, help="Scale parameter for spatial coordinates (in mm)"
     ).tag(config=True)
 
     epsilon_t = FloatTelescopeParameter(
-        default_value=20.0, help="Scale parameter for time (in ns)"
+        default_value=40.0, help="Scale parameter for time (in ns)"
     ).tag(config=True)
 
     def __init__(self, subarray, config=None, parent=None, **kwargs):

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -14,8 +14,6 @@ from ctapipe.core.traits import (
     IntTelescopeParameter
 )
 
-from ctapipe.core.component import TelescopeComponent
-
 from ctapipe.image import (
     ImageCleaner,
     ImageProcessor,

--- a/sst1mpipe/utils/cleaning.py
+++ b/sst1mpipe/utils/cleaning.py
@@ -186,7 +186,7 @@ class DBSCANImageCleaner(ImageCleaner):
 
     def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray = None) -> np.ndarray:
 
-        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
+        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed', n_jobs=-1)
         clustering.fit(self._distances[tel_id], sample_weight=image)
 
         mask = clustering.labels_ >= 0
@@ -238,8 +238,8 @@ class TimeDBSCANImageCleaner(ImageCleaner):
         self._precompute_distances_squared()
 
     def __call__(self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray) -> np.ndarray:
-        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed')
 
+        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed', n_jobs=-1)
         times = arrival_times / self.epsilon_t.tel[tel_id]
         d = (times[:, None] - times[None, :])**2 + self._distances_squared[tel_id]
         d = np.sqrt(d)
@@ -260,6 +260,70 @@ class TimeDBSCANImageCleaner(ImageCleaner):
             d /= self.epsilon_r.tel[tel_id] * u.mm
 
             self._distances_squared[tel_id] = d**2
+
+class DBSCANImageCleaner3D(ImageCleaner):
+    """
+       An image cleaner based on the sklearn.cluster.DBSCAN algorithm that uses the waveforms
+       """
+    minimum_pe = IntTelescopeParameter(
+        default_value=30, help="Minimum number of p.e. in cluster"
+    ).tag(config=True)
+
+    epsilon_r = FloatTelescopeParameter(
+        default_value=38.0, help="Scale parameter for spatial coordinates (in mm)"
+    ).tag(config=True)
+
+    epsilon_t = FloatTelescopeParameter(
+        default_value=40.0, help="Scale parameter for time (in ns)"
+    ).tag(config=True)
+
+    min_samples = IntTelescopeParameter(
+        default_value=1, help="Minimum number of time samples required"
+    ).tag(config=True)
+
+    def __init__(self, subarray, config=None, parent=None, **kwargs):
+        super().__init__(subarray, config, parent, **kwargs)
+
+        self._precompute_distances()
+
+    def __call__(self, tel_id: int, waveform: np.ndarray) -> np.ndarray:
+
+        clustering = DBSCAN(eps=1.0, min_samples=self.minimum_pe.tel[tel_id], metric='precomputed', n_jobs=-1)
+        clustering.fit(self._distances[tel_id], sample_weight=waveform.ravel())
+
+        mask = clustering.labels_ >= 0
+        mask = mask.reshape((self.subarray.tel[tel_id].camera.readout.n_pixels, self.subarray.tel[tel_id].camera.readout.n_samples))
+        mask = mask.sum(axis=-1)
+        mask = mask >= self.min_samples.tel[tel_id]
+
+        return mask
+
+    def _precompute_distances(self):
+
+        self._distances = {}
+
+        for tel_id in self.subarray.tel_ids:
+
+            geometry = self.subarray.tel[tel_id].camera.geometry
+            readout = self.subarray.tel[tel_id].camera.readout
+
+            t = np.arange(readout.n_samples) / readout.sampling_rate
+
+
+            indices_xyt = np.column_stack([
+                np.repeat(geometry.pix_x.to(u.mm).value / self.epsilon_r.tel[tel_id], readout.n_samples),
+                np.repeat(geometry.pix_y.to(u.mm).value / self.epsilon_r.tel[tel_id], readout.n_samples),
+                np.tile(t.to(u.ns).value / self.epsilon_t.tel[tel_id], geometry.n_pixels)
+            ])
+
+            d = radius_neighbors_graph(indices_xyt, 1.0, mode="distance",
+                                           include_self=True)
+            d = sort_graph_by_row_values(
+                d,
+                warn_when_not_sorted=False
+            )
+
+            self._distances[tel_id] = d
 
 def image_cleaner_setup(subarray=None, config=None, ismc=False):
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,12 +1,15 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from ctapipe.image.cleaning import apply_time_delta_cleaning
+from ctapipe.image.cleaning import apply_time_delta_cleaning, ImageCleaner
 
 from sst1mpipe.instrument.camera import Camera
+from sst1mpipe.io.sst1m_event_source import SST1MEventSource
+from sst1mpipe.utils.cleaning import DBSCANImageCleaner, TimeDBSCANImageCleaner, DBSCANImageCleaner3D
 
 CAMERA = Camera()
 GEOMETRY = CAMERA.geometry
+SUBARRAY = SST1MEventSource.create_subarray()
 
 def test_sparse_matrix():
 
@@ -20,4 +23,15 @@ def test_apply_time_delta_cleaning():
     times = np.ones(GEOMETRY.n_pixels)
 
     apply_time_delta_cleaning(GEOMETRY, mask, times, min_number_neighbors = 1, time_limit = 8)
+
+
+def test_load_DBSCANCleaning_from_name():
+
+
+    cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='DBSCANImageCleaner')
+    assert type(cleaner) == DBSCANImageCleaner
+    cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='TimeDBSCANImageCleaner')
+    assert type(cleaner) == TimeDBSCANImageCleaner
+    cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='DBSCANImageCleaner3D')
+    assert type(cleaner) == DBSCANImageCleaner3D
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -29,9 +29,9 @@ def test_load_DBSCANCleaning_from_name():
 
 
     cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='DBSCANImageCleaner')
-    assert type(cleaner) == DBSCANImageCleaner
+    assert isinstance(cleaner, DBSCANImageCleaner)
     cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='TimeDBSCANImageCleaner')
-    assert type(cleaner) == TimeDBSCANImageCleaner
+    assert isinstance(cleaner, TimeDBSCANImageCleaner)
     cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='DBSCANImageCleaner3D')
-    assert type(cleaner) == DBSCANImageCleaner3D
+    assert isinstance(cleaner, DBSCANImageCleaner3D)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -10,7 +10,6 @@ from ctapipe.image.cleaning import apply_time_delta_cleaning, ImageCleaner
 from traitlets.config import Config
 
 from sst1mpipe.instrument.camera import Camera
-from sst1mpipe.io.sst1m_event_source import SST1MEventSource
 from sst1mpipe.utils.cleaning import DBSCANImageCleaner, TimeDBSCANImageCleaner, DBSCANImageCleaner3D
 
 SUBARRAY_FILE = files('sst1mpipe.data').joinpath(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,7 +1,9 @@
 import numpy as np
+from ctapipe.image import ImageProcessor
 from scipy.sparse import csr_matrix
 
 from ctapipe.image.cleaning import apply_time_delta_cleaning, ImageCleaner
+from traitlets.config import Config
 
 from sst1mpipe.instrument.camera import Camera
 from sst1mpipe.io.sst1m_event_source import SST1MEventSource
@@ -35,3 +37,20 @@ def test_load_DBSCANCleaning_from_name():
     cleaner = ImageCleaner.from_name(subarray=SUBARRAY, name='DBSCANImageCleaner3D')
     assert isinstance(cleaner, DBSCANImageCleaner3D)
 
+def test_DBSCAN_configurable_from_image_processor():
+
+    config = Config({"ImageProcessor": {
+        "image_cleaner_type": "DBSCANImageCleaner",
+        "use_telescope_frame": False,
+        "DBSCANImageCleaner": {
+            "epsilon_r": [
+                ["id", 1, 38],
+                ["id", 2, 38]
+            ],
+            "minimum_pe": [
+                ["id", 1, 30],
+                ["id", 2, 30]
+            ]
+        }}})
+
+    ImageProcessor(subarray=SUBARRAY, config=config)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,9 @@
+from importlib.resources import files
+import astropy.units as u
+
 import numpy as np
 from ctapipe.image import ImageProcessor
+from ctapipe.instrument import SubarrayDescription
 from scipy.sparse import csr_matrix
 
 from ctapipe.image.cleaning import apply_time_delta_cleaning, ImageCleaner
@@ -9,9 +13,13 @@ from sst1mpipe.instrument.camera import Camera
 from sst1mpipe.io.sst1m_event_source import SST1MEventSource
 from sst1mpipe.utils.cleaning import DBSCANImageCleaner, TimeDBSCANImageCleaner, DBSCANImageCleaner3D
 
+SUBARRAY_FILE = files('sst1mpipe.data').joinpath(
+    'sst1m_array.h5'
+)
+
 CAMERA = Camera()
 GEOMETRY = CAMERA.geometry
-SUBARRAY = SST1MEventSource.create_subarray()
+SUBARRAY =  SubarrayDescription.from_hdf(SUBARRAY_FILE)
 
 def test_sparse_matrix():
 
@@ -44,13 +52,29 @@ def test_DBSCAN_configurable_from_image_processor():
         "use_telescope_frame": False,
         "DBSCANImageCleaner": {
             "epsilon_r": [
-                ["id", 1, 38],
-                ["id", 2, 38]
+                ["id", 21, 38],
+                ["id", 22, 38]
             ],
             "minimum_pe": [
-                ["id", 1, 30],
-                ["id", 2, 30]
+                ["id", 21, 30],
+                ["id", 22, 30]
             ]
         }}})
 
     ImageProcessor(subarray=SUBARRAY, config=config)
+
+def test_DBSCANImageCleaner():
+
+    image = np.ones(GEOMETRY.n_pixels)
+
+    epsilon_r = (np.sqrt(GEOMETRY.pix_area[0] / np.sqrt(3.0) / 2)).to(u.mm).value * 2 # 2 pixel to pixel distance
+
+
+    n_pixels = [GEOMETRY.n_pixels, 1284, 1282, 1242, 857, 345, 133, 0, 0]
+
+    for i in range(9):
+
+        cleaner = DBSCANImageCleaner(subarray=SUBARRAY, minimum_pe=[("id", 21, i+1), ("id", 22, i+1)],
+                                     epsilon_r=[("id", 21, epsilon_r), ("id", 22, epsilon_r)])
+        mask = cleaner(21, image)
+        assert mask.sum() == n_pixels[i]


### PR DESCRIPTION
This PR includes : 

1. DBSCAN Image Cleaner (2D and 2D+Time) 
2. Update to ctapipe 0.18.1 which allows to make child of TelescopeComponent Configurable via .json files (this limited the creation of custom component inheriting from ctapipe objects.
3. Unit tests form the 2D DBSCAN Image Cleaner